### PR TITLE
プランナーの受付枠を削除

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -24,6 +24,12 @@ class SchedulesController < ApplicationController
     redirect_to new_schedule_path
   end
 
+  def destroy
+    Schedule.find(params[:id]).destroy
+    flash[:success] = 'スケジュールを削除しました'
+    redirect_to current_user
+  end
+
   private
   
   def schedule_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @events = Schedule.where(user: current_user) + Reservation.where(user: current_user)
+    @events = Schedule.where(user: @user) + Reservation.where(user: @user)
   end
 
   private

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,4 +8,8 @@ class Schedule < ApplicationRecord
   def end_time
     self.start_time + 30.minutes
   end
+
+  def is_reserved?
+    Reservation.where(schedule: self).count > 0
+  end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,6 +1,6 @@
 class Schedule < ApplicationRecord
   belongs_to :user
-  has_one :reservation
+  has_one :reservation, dependent: :destroy
 
   validates :start_time, presence: true, uniqueness: { scope: :user }
   validates_with ScheduleValidator

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
   validates :password, presence: true, length: { minimum: 8 }
 
-  has_many :reservations
-  has_many :schedules
+  has_many :reservations, dependent: :destroy
+  has_many :schedules, dependent: :destroy
 
   private
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,8 @@ html
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css'
+    script src='https://cdn.jsdelivr.net/npm/flatpickr'
   body
     = render 'layouts/header'
 

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -17,9 +17,13 @@ h1 受付枠検索
       = link_to schedule.user.name, schedule.user
       = schedule.start_time.strftime(' %Y/%m/%d %H:%M')
       = schedule.end_time.strftime('-%H:%M')
-      .form-inline
-        .form-group.mb-2
-          = form_with model: @reservation, local: true do |f|
-            = f.hidden_field :schedule_id, :value => schedule.id
-            = f.submit 'この枠を予約する', class: 'btn btn-secondary'
+
+      - if current_user == schedule.user
+        p.text-muted 自身が作成した受付枠です
+      - elsif !schedule.is_reserved?
+        .form-inline
+          .form-group.mb-2
+            = form_with model: @reservation, local: true do |f|
+              = f.hidden_field :schedule_id, :value => schedule.id
+              = f.submit 'この枠を予約する', class: 'btn btn-secondary'
 = paginate @schedules

--- a/app/views/shared/_simple_calendar.html.slim
+++ b/app/views/shared/_simple_calendar.html.slim
@@ -7,6 +7,8 @@
         .schedule
           - if event.reservation.nil?
             = event.start_time.strftime('%H:%M')
+            = link_to ' 削除', schedule_path(event.id), method: :delete,
+              data: { confirm: "#{event.start_time.strftime('%m/%d %H:%M')}-#{event.end_time.strftime('%H:%M')}の予定を削除しますか？" }
           - else
             = event.reservation.user.name
             = event.start_time.strftime(' %H:%M')

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -1,8 +1,19 @@
 - provide(:title, 'Home')
 
-.center.jumbotron
-  h1 Welcome
+- if logged_in?
+  .center
+    h3 FPに相談したいユーザーの方はこちら
+    = link_to 'FPの受付枠を検索', schedules_path, class: 'btn btn-lg btn-primary'
 
-  h2 This is the home page of fp_reservation.
+    hr
 
-  = link_to 'Sign up now!', new_user_path, class: 'btn btn-lg btn-primary'
+    h3 FPの方はこちら
+    = link_to '受付枠を作成', new_schedule_path, class: 'btn btn-lg btn-secondary'
+
+- else
+  .center.jumbotron
+    h1 Welcome
+
+    h2 This is the home page of fp_reservation.
+
+    = link_to 'Sign up now!', new_user_path, class: 'btn btn-lg btn-primary'


### PR DESCRIPTION
### このPRでやったこと
- UserモデルにScheduleとReservationに対する`dependent: :destroy`を追加
- 未予約のScheduleをカレンダーから削除できる実装
- 他人のユーザーページでも、現在ログイン中のユーザーのScheduleとReservationが表示されていたバグを修正
- トップページを未ログイン/ログイン済みの場合で違う内容を表示するよう変更
- 受付枠検索画面で自分が作成した枠はそれが分かるように明示し、予約済みの枠は表示しないように修正
- [ここ](https://app-fp-reservation.herokuapp.com/)にデプロイした

### スクリーンショット
- カレンダー上の予約枠削除ボタン
- 削除を押した時の確認ダイアログ
- ダイアログでOKを押した後の画面
の順で掲載しています

<img width="500" alt="スクリーンショット 2020-09-04 14 42 33" src="https://user-images.githubusercontent.com/54789214/92203841-1f533d80-eebd-11ea-874d-13e0a6c943fa.png">
<img width="464" alt="スクリーンショット 2020-09-04 14 45 14" src="https://user-images.githubusercontent.com/54789214/92203927-4d388200-eebd-11ea-9ac4-7cc6e030511f.png">
<img width="500" alt="スクリーンショット 2020-09-04 14 42 58" src="https://user-images.githubusercontent.com/54789214/92203846-22e6c480-eebd-11ea-9901-ca512d6a2b71.png">
